### PR TITLE
RunningRoverC  example mistake 

### DIFF
--- a/examples/RoverC_M5StickC/RunningRoverC/RunningRoverC.ino
+++ b/examples/RoverC_M5StickC/RunningRoverC/RunningRoverC.ino
@@ -3,7 +3,7 @@
 
 TFT_eSprite canvas = TFT_eSprite(&M5.Lcd);
 
-M5_ROVERC roverc;
+M5_RoverC roverc;
 
 void setup() {
     M5.begin();

--- a/examples/RoverC_M5StickCPlus/RunningRoverC/RunningRoverC.ino
+++ b/examples/RoverC_M5StickCPlus/RunningRoverC/RunningRoverC.ino
@@ -2,6 +2,7 @@
 #include "M5_RoverC.h"
 
 TFT_eSprite canvas = TFT_eSprite(&M5.Lcd);
+M5_RoverC roverc;
 
 void setup() {
     M5.begin();


### PR DESCRIPTION
-  M5-RoverC/examples/RoverC_M5StickC/RunningRoverC/RunningRoverC.ino
 M5_ROVERC→M5_RoverC

-  M5-RoverC/examples/RoverC_M5StickCPlus/RunningRoverC/RunningRoverC.ino
 M5_RoverC roverc; is required but not available.
 
